### PR TITLE
[PD-46] Fixed header not scrolling slower on Pokemon Details page

### DIFF
--- a/src/components/pokemons/PokemonItem.vue
+++ b/src/components/pokemons/PokemonItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <BaseLoader :loading="loading" :coverPage="true">
+  <BaseLoader :loading="loading" :coverPage="true" mode="in-out">
     <CenteredColumn class="pokemon-item" ref="pokemonItem">
       <PokemonItemHeader
         id="header"
@@ -59,12 +59,23 @@ export default {
     return {
       topPosition: 0,
       throttledParallax: null,
-      loading: false,
+      loading: true,
     };
   },
   watch: {
     name() {
       document.title = `Pokedex - ${capitalizeWord(this.name ?? '')}`;
+    },
+    async loading() {
+      if (this.loading) {
+        return;
+      }
+      await this.$nextTick();
+      this.throttledParallax = throttle(this.parallax, 20);
+      getPokemonPageBackgroundElement().addEventListener(
+        'scroll',
+        this.throttledParallax
+      );
     },
   },
   computed: {
@@ -89,20 +100,9 @@ export default {
   },
   async created() {
     if (!store.state.pokemon.has(this.urlId)) {
-      this.loading = true;
       await store.getPokemon(this.urlId);
-      this.loading = false;
     }
-  },
-  async onUpdated() {
-    if (this.loading) {
-      return;
-    }
-    this.throttledParallax = throttle(this.parallax, 20);
-    getPokemonPageBackgroundElement().addEventListener(
-      'scroll',
-      this.throttledParallax
-    );
+    this.loading = false;
   },
   beforeDestroy() {
     getPokemonPageBackgroundElement().removeEventListener(

--- a/src/components/ui/BaseLoader.vue
+++ b/src/components/ui/BaseLoader.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="fade-in-out" mode="out-in">
+  <transition name="fade-in-out" :mode="mode" appear>
     <FontAwesomeIcon
       v-if="loading"
       icon="fa-solid fa-spinner"
@@ -18,6 +18,10 @@ export default {
     loading: {
       type: Boolean,
       required: true,
+    },
+    mode: {
+      type: String,
+      default: 'out-in',
     },
     coverPage: {
       type: Boolean,


### PR DESCRIPTION
**Ticket**
[PD-46](https://trello.com/c/BZ5F16Cz/48-pd-46-header-on-pokemon-detail-page-is-not-scrolling-slower)

**Tasks**
- Fixed header not scrolling slower on Pokemon Details page