### PR TITLE
[PD-48] Fixed scroll to top button on details and list pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
           <router-view :key="$route.fullPath" />
         </transition>
         <transition name="drawer-down">
-          <BaseFooter v-if="displayFooter" />
+          <BaseFooter :displayFooter="displayFooter" />
         </transition>
       </CenteredColumn>
     </CenteredColumn>


### PR DESCRIPTION
**Ticket**
[PD-48
](https://trello.com/c/2XYVWuN2/51-pd-48-scroll-to-top-button-doesnt-show-up-on-pokemon-details-or-pokemons-page)
**Tasks**
- Fixed scroll to top button on details and list pages