### PR TITLE
[PD-57] Fix displaying default photo on Pokemon Details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ##### Fixed
 
 - Pokemon Game: input clears when getting a new pokemon
+- Pokemon Details: fixed issues with missing properties
 
 ---
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -14,8 +14,8 @@ export function scrollToTopOfBackgroundPokemonPage() {
   getPokemonPageBackgroundElement()?.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
-export function capitalizeWord(word) {
-  const firstLetter = (word ?? '').charAt(0).toUpperCase();
+export function capitalizeWord(word = '') {
+  const firstLetter = word.charAt(0).toUpperCase();
   const remainingLetters = word.substring(1);
   return `${firstLetter}${remainingLetters}`;
 }

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -7,7 +7,6 @@ import {
 } from '@api/pokemon';
 import { isDarkModeEnabled } from '@lib/localStorage';
 import { toggleDarkMode as toggleDarkModeInLocalStorage } from './localStorage';
-import silouette from '@assets/pokemons/silouette.png';
 
 const state = Vue.observable({
   allPokemons: [],
@@ -70,7 +69,9 @@ export default {
     const stats = pokemon.stats.map((s) => {
       return { name: s.stat.name, value: s.base_stat };
     });
-    const image = pokemon.sprites.other.dream_world.front_default ?? silouette;
+    const image =
+      pokemon.sprites.other.dream_world.front_default ??
+      pokemon.sprites.front_default;
     const types = pokemon.types.map((t) => t.type.name);
     const name = pokemon.name;
     const id = pokemon.id;


### PR DESCRIPTION
**Ticket**
[PD-57
](https://trello.com/c/xZTbudrI/60-pd-57-pokemon-details-if-no-image-is-found-use-the-frontdefault)
**Tasks**
- Fix displaying default photo on Pokemon Details page