### PR TITLE
[PD-76] Bugfix: pokemon list page no longer shows error message when loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased](https://github.com/nashaguayo/pokedex/compare/V0.1.3...HEAD) (dd-mm-yyyy)
 
+##### Fixed
+
+- Pokemon list: no error message displays when loading
+
 ---
 
 ## [V0.1.3](https://github.com/nashaguayo/pokedex/compare/V0.1.2...V0.1.3) (11-07-2023)

--- a/src/components/pokemons/PokemonList.vue
+++ b/src/components/pokemons/PokemonList.vue
@@ -1,6 +1,6 @@
 <template>
   <CenteredColumn class="pokemon-list">
-    <template v-if="!pokemons.length">
+    <template v-if="!pokemons.length && !loading">
       <h2>Something went wrong!</h2>
       <p>No pokemons to display.</p>
     </template>
@@ -88,6 +88,10 @@ export default {
 
   .search {
     margin-bottom: 1rem;
+
+    @media (min-width: $min-width-second-break) {
+      margin-bottom: 2rem;
+    }
   }
 
   .pokemons {
@@ -112,9 +116,6 @@ export default {
     @media (min-width: $min-width-fifth-break) {
       grid-template-columns: repeat(5, 1fr);
     }
-  }
-
-  .header {
   }
 }
 


### PR DESCRIPTION
**Ticket**
[PD-76](https://trello.com/c/hKUOeufa/79-pd-76-pokemon-list-page-displays-message-that-something-was-wrong-too-soon)

**Tasks**
- Pokemon list page no longer shows error message when loading