### PR TITLE
[PD-131] Fixed pokemon stat bars missing when exceeding ones appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Scroll to top button bottom margin when navigating away from a page with footer
 - Search on mobile
 - Undefined characteristics for species
+- Added missing empty stat bars when exceeding bars appear
 
 ---
 

--- a/src/components/pokemon/PokemonItemStats.vue
+++ b/src/components/pokemon/PokemonItemStats.vue
@@ -1,8 +1,8 @@
-<template functional>
+<template>
   <div class="pokemon-item-stats">
     <span class="title">Stats</span>
     <div
-      v-for="stat in props.stats"
+      v-for="stat in stats"
       :key="`stat-${stat.name}`"
       class="pokemon-item-stat"
     >
@@ -22,18 +22,18 @@
             :key="`bar-filled-${n}`"
           ></div>
         </template>
-        <template v-if="10 - Math.floor(stat.value / 10) > 0">
-          <div
-            class="bar empty"
-            v-for="n in 10 - Math.floor(stat.value / 10)"
-            :key="`bar-empty-${n}`"
-          ></div>
-        </template>
         <template v-if="Math.floor((stat.value - 100) / 10) > 0">
           <div
             class="bar exceeded"
             v-for="n in Math.floor((stat.value - 100) / 10)"
             :key="`bar-exceeded-${n}`"
+          ></div>
+        </template>
+        <template v-if="10 + exceedingBars - Math.floor(stat.value / 10) > 0">
+          <div
+            class="bar empty"
+            v-for="n in 10 + exceedingBars - Math.floor(stat.value / 10)"
+            :key="`bar-empty-${n}`"
           ></div>
         </template>
       </div>
@@ -49,6 +49,19 @@ export default {
     stats: {
       type: Array,
       required: true,
+    },
+  },
+  computed: {
+    exceedingBars() {
+      let exceedingBars = 0;
+      let highestValue = 0;
+      this.stats.map((stat) => {
+        if (stat.value > highestValue && stat.value > 110) {
+          highestValue = stat.value;
+          exceedingBars = Math.floor((stat.value - 100) / 10);
+        }
+      });
+      return exceedingBars;
     },
   },
 };

--- a/tests/unit/components/pokemon/PokemonItemStats.test.js
+++ b/tests/unit/components/pokemon/PokemonItemStats.test.js
@@ -62,7 +62,7 @@ describe('PokemonItemStats', () => {
     const exceededBars = wrapper.findAll('.exceeded');
 
     expect(filledBars.length).toBe(17);
-    expect(emptyBars.length).toBe(13);
+    expect(emptyBars.length).toBe(15);
     expect(exceededBars.length).toBe(1);
   });
 
@@ -83,8 +83,8 @@ describe('PokemonItemStats', () => {
     });
 
     expect(statBarsData).toEqual([
-      { filledBars: 5, emptyBars: 5, exceededBars: 0 },
-      { filledBars: 2, emptyBars: 8, exceededBars: 0 },
+      { filledBars: 5, emptyBars: 6, exceededBars: 0 },
+      { filledBars: 2, emptyBars: 9, exceededBars: 0 },
       { filledBars: 10, emptyBars: 0, exceededBars: 1 },
     ]);
   });


### PR DESCRIPTION
**Ticket**
[PD-131](https://trello.com/c/ts5bRRO7/135-pd-131-fix-pokemon-stat-bars-missing-when-exceeding-ones-appear)

**Tasks**
- Fixed pokemon stat bars missing when exceeding ones appear