### PR TITLE
[PD-156] Fixed empty stat bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Base Loader is now at center of page
 - Random Pokemon and Guess Pokemon not finishing loading
 - Animation in search items
+- Amount of empty stat bars
 
 ---
 

--- a/src/components/pokemon/PokemonItemStats.vue
+++ b/src/components/pokemon/PokemonItemStats.vue
@@ -56,7 +56,7 @@ export default {
       let exceedingBars = 0;
       let highestValue = 0;
       this.stats.map((stat) => {
-        if (stat.value > highestValue && stat.value > 110) {
+        if (stat.value > highestValue && stat.value >= 110) {
           highestValue = stat.value;
           exceedingBars = Math.floor((stat.value - 100) / 10);
         }


### PR DESCRIPTION
**Ticket**
[PD-156](https://trello.com/c/Gw0Xy7HF/160-pd-156-sometimes-stat-bars-dont-load-the-correct-amount-of-empty-bars)

**Tasks**
- Fixed empty stat bars